### PR TITLE
Prepare squeeze-it 1.0.1 manifest metadata and changelog

### DIFF
--- a/squeeze-it/CHANGELOG.md
+++ b/squeeze-it/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to `squeeze-it` are documented in this file.
+
+## 1.0.1
+
+- Added manifest metadata improvements:
+  - `system` restriction for `dnd5e`
+  - `license` URL
+  - `changelog` URL
+- Improved release/documentation alignment and workflow hardening around publishing and metadata consistency.
+
+## 1.0.0
+
+- Initial public release of `squeeze-it`.
+- Added size-aware squeezing behavior integrated with Region Modify Movement Cost:
+  - `All`: applies normal multiplier behavior
+  - Specific size selected:
+    - smaller creatures ignore multiplier
+    - equal size uses multiplier
+    - larger creatures are blocked (infinite movement cost)
+- Added Region Behavior sheet UI injection for squeeze size configuration.
+- Added persistence for squeeze-size flag and tooltip guidance in config UI.

--- a/squeeze-it/module.json
+++ b/squeeze-it/module.json
@@ -2,7 +2,10 @@
   "id": "squeeze-it",
   "title": "Squeezing & Crawlspace Rules",
   "description": "Implements size-based squeezing, movement cost, and region-based crawlspace logic.",
-  "version": "1.0.0",
+  "version": "1.0.1",
+  "system": [
+    "dnd5e"
+  ],
   "compatibility": {
     "minimum": "13",
     "verified": "13.351",
@@ -11,7 +14,9 @@
   "url": "https://github.com/pgarm/FoundryVTT",
   "manifest": "https://github.com/pgarm/FoundryVTT/releases/download/modules-latest/squeeze-it-module.json",
   "download": "https://github.com/pgarm/FoundryVTT/releases/download/modules-latest/squeeze-it.zip",
+  "license": "https://github.com/pgarm/FoundryVTT/blob/main/LICENSE",
   "readme": "https://github.com/pgarm/FoundryVTT/blob/main/squeeze-it/README.md",
+  "changelog": "https://github.com/pgarm/FoundryVTT/blob/main/squeeze-it/CHANGELOG.md",
   "bugs": "https://github.com/pgarm/FoundryVTT/issues",
   "authors": [
     {


### PR DESCRIPTION
## Summary
- Bump squeeze-it to `1.0.1`.
- Add recommended manifest metadata for marketplace/readiness:
  - `system` restriction (`dnd5e`)
  - license URL
  - `changelog` URL
- Add CHANGELOG.md with entries for `1.0.0` and `1.0.1`.

## Why
- Improve manifest completeness against Foundry module manifest guidance.
- Reduce risk of cross-system activation by explicitly restricting supported system.
- Make release history and licensing clearer for users/reviewers.

## Changes
- Update module.json:
  - `version: "1.0.1"`
  - add `"system": ["dnd5e"]`
  - add `"license": "https://github.com/pgarm/FoundryVTT/blob/main/LICENSE"`
  - add `"changelog": "https://github.com/pgarm/FoundryVTT/blob/main/squeeze-it/CHANGELOG.md"`
- Add CHANGELOG.md:
  - `1.0.0`: initial published module functionality
  - `1.0.1`: metadata/release-readiness updates

## Validation
- Manifest JSON remains valid.
- No runtime behavior/code-path changes in module logic.
- Existing release URL pattern (`modules-latest`) remains unchanged.

## Notes
- This PR is metadata + documentation only.
- Intended to support cleaner package submission/review in Foundry ecosystem.