### PR TITLE
Workflow validate only mode

### DIFF
--- a/.github/workflows/monitor-foundry-compat-alert.yml
+++ b/.github/workflows/monitor-foundry-compat-alert.yml
@@ -153,7 +153,7 @@ jobs:
         if: steps.scan.outputs.non_green_count != '0'
         uses: actions/github-script@v7
         env:
-          ALERT_TITLE: Foundry compatibility alert: ${{ steps.scan.outputs.latest_stable }}
+          ALERT_TITLE: "Foundry compatibility alert: ${{ steps.scan.outputs.latest_stable }}"
           ALERT_BODY_PATH: ${{ steps.scan.outputs.report_path }}
         with:
           script: |


### PR DESCRIPTION
Updated [monitor-foundry-compat-alert.yml](vscode-file://vscode-app/c:/Users/pgarm/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to quote:
ALERT_TITLE: "Foundry compatibility alert: ${{ steps.scan.outputs.latest_stable }}"