### PR TITLE
Require manifest version bump for release-relevant module changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -54,3 +56,100 @@ jobs:
             echo "$tracked_forbidden"
             exit 1
           fi
+
+      - name: Require module version bump for release-relevant PR changes
+        if: github.event_name == 'pull_request'
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          git fetch --no-tags origin "$BASE_SHA" "$HEAD_SHA" || true
+
+          python - <<'PY'
+          import glob
+          import json
+          import os
+          import re
+          import subprocess
+          import sys
+
+          base_sha = os.environ["BASE_SHA"].strip()
+          head_sha = os.environ["HEAD_SHA"].strip()
+
+          changed_paths_output = subprocess.check_output(
+            ["git", "diff", "--name-only", base_sha, head_sha],
+            text=True,
+          )
+          changed_files = set(path.strip() for path in changed_paths_output.splitlines() if path.strip())
+
+          violations = []
+
+          def manifest_version_at(revision: str, manifest_path: str):
+            result = subprocess.run(
+              ["git", "show", f"{revision}:{manifest_path}"],
+              capture_output=True,
+              text=True,
+            )
+            if result.returncode != 0:
+              return None
+
+            try:
+              data = json.loads(result.stdout)
+            except Exception:
+              return None
+
+            version = str(data.get("version", "")).strip()
+            return version or None
+
+          for manifest in sorted(glob.glob("*/module.json")):
+            module_dir = manifest.split("/")[0]
+            module_prefix = f"{module_dir}/"
+
+            module_changed_paths = sorted(path for path in changed_files if path.startswith(module_prefix))
+            if not module_changed_paths:
+              continue
+
+            release_relevant_paths = [
+              path
+              for path in module_changed_paths
+              if not (
+                re.fullmatch(fr"{re.escape(module_dir)}/(?:README\.md|CHANGELOG\.md)", path, flags=re.IGNORECASE)
+                or path.startswith(f"{module_dir}/docs/")
+              )
+            ]
+
+            if not release_relevant_paths:
+              continue
+
+            head_version = manifest_version_at(head_sha, manifest)
+            base_version = manifest_version_at(base_sha, manifest)
+
+            if head_version is None:
+              violations.append(
+                (module_dir, release_relevant_paths, "unable to read head manifest version")
+              )
+              continue
+
+            if base_version == head_version:
+              violations.append(
+                (
+                  module_dir,
+                  release_relevant_paths,
+                  f"version unchanged ({head_version})",
+                )
+              )
+
+          if violations:
+            print("Release-relevant module changes require a module.json version bump:\n")
+            for module_dir, paths, reason in violations:
+              print(f"- {module_dir}: {reason}")
+              for path in paths:
+                print(f"    - {path}")
+            print("\nUpdate the affected module's module.json version before merging.")
+            sys.exit(1)
+
+          print("Version bump gate passed for all release-relevant module changes.")
+          PY

--- a/.github/workflows/publish-changed-modules.yml
+++ b/.github/workflows/publish-changed-modules.yml
@@ -41,6 +41,7 @@ jobs:
           set -euo pipefail
 
           mode="changed"
+          before_sha=""
           if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
             mode="${{ inputs.scope }}"
           fi
@@ -68,14 +69,38 @@ jobs:
             fi
           fi
 
+          export BASE_SHA="$before_sha"
+
           detect_json="$(python - <<'PY'
           import glob
           import json
           import os
           import re
+          import subprocess
 
           mode = os.environ["MODE"]
           changed_file_list = os.environ["CHANGED_FILE_LIST"]
+          base_sha = os.environ.get("BASE_SHA", "").strip()
+
+          def manifest_version_at(revision, manifest_path):
+            if not revision:
+              return None
+
+            result = subprocess.run(
+              ["git", "show", f"{revision}:{manifest_path}"],
+              capture_output=True,
+              text=True,
+            )
+            if result.returncode != 0:
+              return None
+
+            try:
+              data = json.loads(result.stdout)
+            except Exception:
+              return None
+
+            version = str(data.get("version", "")).strip()
+            return version or None
 
           changed_files = None
           if mode != "all":
@@ -112,6 +137,11 @@ jobs:
 
             if not module_id or not version_raw:
               raise SystemExit(f"Invalid module manifest: {manifest} (id/version required)")
+
+            if changed_files is not None and mode == "changed":
+              base_version = manifest_version_at(base_sha, manifest)
+              if base_version == version_raw:
+                continue
 
             tag_version = version_raw if version_raw.startswith("v") else f"v{version_raw}"
             modules.append({

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,9 +55,17 @@ This repository supports independent module release cadence.
 - Behavior:
   - Detects module folders changed in the merge/push to `main`
   - Reads each changed module's `id` and `version` from `module.json`
+  - In `scope=changed`, only publishes a module when its `module.json` version changed in the merged range
   - Creates a record tag per changed module (`<module-folder>/v<version>`)
   - Publishes module assets to that tag release
   - Updates rolling module assets on `modules-latest`
+
+#### Version bump gate policy
+
+- Release intent is controlled by `module.json` version changes.
+- Non-release paths (`README.md`, `CHANGELOG.md`, `docs/**`) do not trigger per-version release in changed mode.
+- PRs that modify release-relevant module files without changing that module's `module.json` version are blocked by CI.
+- To merge release-relevant module changes, manually bump the module version in `module.json` (semantic part is maintainer choice).
 
 #### Release checklist (local vs GitHub web)
 


### PR DESCRIPTION
### What changed
- Added a PR CI gate in [ ci.yml ](.github/workflows/ci.yml):
  - If release-relevant files under a module change, that module’s module.json version must also change.
  - Non-release paths are excluded from this check: README.md, `CHANGELOG.md`, `docs/**`.
- Updated [ publish-changed-modules.yml ](.github/workflows/publish-changed-modules.yml):
  - In `scope=changed`, a module is published only when its manifest version changed in the compared range.
  - Prevents docs-only merges from attempting to republish an existing tag.
- Updated policy docs in CONTRIBUTING.md under release model/version-bump gate.

### Validation
- VS Code workflow diagnostics: no errors.
- `actionlint` (official binary): clean.

### Resulting behavior
- `version changed` ⇒ full release pipeline (tag/build/release/Foundry notify).
- `version unchanged + non-release paths only` ⇒ no release.
- `version unchanged + release-relevant module changes` ⇒ PR blocked until version bump.